### PR TITLE
Fix `LoadBalancer` resource generation

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -30,27 +30,25 @@ local secret = function(name) {
   },
 };
 
-local loadbalancers = [
-  {
-    local value = params.loadbalancers[name],
-    apiVersion: 'cloudscale.appuio.io/v1beta1',
-    kind: 'LoadBalancer',
-    metadata: {
-      name: name,
-      namespace: params.namespace,
-    },
-    spec+: {
-      _pools+:: [],
-      pools+: [
-        value.spec._pools[poolName] {
-          name: poolName,
-        }
-        for poolName in std.objectFields(value.spec._pools)
-      ],
-    },
-  }
-  for name in std.objectFields(params.loadbalancers)
-];
+local LoadBalancer(name) = {
+  apiVersion: 'cloudscale.appuio.io/v1beta1',
+  kind: 'LoadBalancer',
+  metadata: {
+    name: name,
+    namespace: params.namespace,
+  },
+  spec+: {
+    _pools+:: {},
+    pools+: [
+      self._pools[poolName] {
+        name: poolName,
+      }
+      for poolName in std.objectFields(self._pools)
+    ],
+  },
+};
+
+local loadbalancers = com.generateResources(params.loadbalancers, LoadBalancer);
 
 local secrets = com.generateResources(params.secrets, secret);
 

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -17,6 +17,8 @@ parameters:
     loadbalancers:
       api:
         spec:
+          floatingIPAddresses:
+            - cidr: 192.0.2.100/32
           _pools:
             http:
               frontend:

--- a/tests/golden/defaults/cloudscale-loadbalancer-controller/cloudscale-loadbalancer-controller/20_loadbalancers.yaml
+++ b/tests/golden/defaults/cloudscale-loadbalancer-controller/cloudscale-loadbalancer-controller/20_loadbalancers.yaml
@@ -4,6 +4,8 @@ metadata:
   name: api
   namespace: appuio-cloudscale-loadbalancer-controller
 spec:
+  floatingIPAddresses:
+    - cidr: 192.0.2.100/32
   pools:
     - backend:
         healthMonitor:


### PR DESCRIPTION
Fix `LoadBalancer` resource generation to not drop all fields other than `_pools`. The commit also refactors the generation logic to use `com.generateResources()`.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
