### PR TITLE
Deploy `LoadBalancer` viewer clusterrole

### DIFF
--- a/component/cloudscale_loadbalancer_controller.jsonnet
+++ b/component/cloudscale_loadbalancer_controller.jsonnet
@@ -25,6 +25,9 @@ local cloudscale_loadbalancer_controller = com.Kustomization(
     },
   },
   {
+    resources: [
+      'https://raw.githubusercontent.com/appuio/cloudscale-loadbalancer-controller/%s/config/rbac/loadbalancer_viewer_role.yaml' % [ params.manifest_version ],
+    ],
     // Inner kustomization layers are immutable, so we need to re-replace the namespace after changing it in an outer layer
     replacements: [
       {

--- a/tests/golden/defaults/cloudscale-loadbalancer-controller/cloudscale-loadbalancer-controller/10_kustomize/cloudscale_loadbalancer_controller/rbac.authorization.k8s.io_v1_clusterrole_cloudscale-loadbalancer-viewer-role.yaml
+++ b/tests/golden/defaults/cloudscale-loadbalancer-controller/cloudscale-loadbalancer-controller/10_kustomize/cloudscale_loadbalancer_controller/rbac.authorization.k8s.io_v1_clusterrole_cloudscale-loadbalancer-viewer-role.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: cloudscale-loadbalancer-controller
+    app.kubernetes.io/instance: cloudscale-loadbalancer-viewer-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: cloudscale-loadbalancer-controller
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  name: cloudscale-loadbalancer-viewer-role
+rules:
+- apiGroups:
+  - cloudscale.appuio.io
+  resources:
+  - loadbalancers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudscale.appuio.io
+  resources:
+  - loadbalancers/status
+  verbs:
+  - get


### PR DESCRIPTION
The role already has the aggregation label for the cluster-reader clusterrole.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
