### PR TITLE
Add support for optional floating IP addresses

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -38,7 +38,16 @@ local LoadBalancer(name) = {
     namespace: params.namespace,
   },
   spec+: {
+    local this = self,
     _pools+:: {},
+    _floatingIPAddresses+:: {},
+    floatingIPAddresses+: [
+      { cidr: '%(address)s/%(prefixlength)d' % this._floatingIPAddresses[name] }
+      for name in std.objectFields(self._floatingIPAddresses)
+      if
+        std.isObject(self._floatingIPAddresses[name]) &&
+        !std.member([ null, '' ], self._floatingIPAddresses[name].address)
+    ],
     pools+: [
       self._pools[poolName] {
         name: poolName,
@@ -48,7 +57,22 @@ local LoadBalancer(name) = {
   },
 };
 
-local loadbalancers = com.generateResources(params.loadbalancers, LoadBalancer);
+// NOTE(sg): We need to remove duplicates after the call to
+// `com.generateResources()`, since doing this snippet in `LoadBalancer(name)`
+// doesn't see floating IPs configured via `_floatingIPAddresses` due to how
+// layered objects work in Jsonnet.
+local removeDuplicateFloatingIPAddresses(lb) = lb {
+  spec+: {
+    floatingIPAddresses: std.uniq(std.sort(
+      super.floatingIPAddresses, function(it) it.cidr
+    )),
+  },
+};
+
+local loadbalancers = std.map(
+  removeDuplicateFloatingIPAddresses,
+  com.generateResources(params.loadbalancers, LoadBalancer)
+);
 
 local secrets = com.generateResources(params.secrets, secret);
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -63,6 +63,13 @@ example::
 ----
 api:
   spec:
+    _floatingIPAddresses:
+      default:
+        address: 192.0.2.100
+        prefixlength: 32
+      partial: <1>
+        address: ""
+        prefixlength: 128
     _pools:
       https:
         frontend:
@@ -75,6 +82,7 @@ api:
           healthMonitor:
             type: TCP
 ----
+<1> Skipped by the rendering logic because `address` is `""`.
 
 Allows specifying load balancers.
 The dictionary keys are the load balancer names, and the values are the load balancer manifests.
@@ -82,6 +90,14 @@ The dictionary keys are the load balancer names, and the values are the load bal
 `.spec._pools` allows defining the load balancer pool configurations that can be overridden in the hierarchy.
 The `.spec._pools` dictionary keys are used as the pool names while the values are the pool configurations.
 `.spec._pools` are merged into the upstream `.spec.pools` configurations.
+
+`.spec._floatingIPAddresses` allows defining floating addresses that can be overridden and customized in the hierarchy.
+The `.spec._floatingIPAddresses` keys are ignored.
+Entries whose value isn't an object and entries whose `.address` is `null` or `""` are skipped.
+Other malformed entries may cause a compilation error.
+Values are rendered as `%(address)s/%(prefixlength)d` for field `cidr` in `spec.floatingIPAddresses` without validating that the resulting string is a valid floating IP in CIDR notation.
+`.spec._floatingIPAddresses` is merged into the provided `.spec.floatingIPAddresses` and duplicates are removed.
+The component doesn't guarantee any particular entry order for the final `.spec.floatingIPAddresses`.
 
 == `images`
 

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -19,6 +19,18 @@ parameters:
         spec:
           floatingIPAddresses:
             - cidr: 192.0.2.100/32
+            - cidr: 3fff::100/128
+          _floatingIPAddresses:
+            router-v4:
+              address: 192.0.2.100
+              prefixlength: 32
+            router-v6:
+              address: 3fff::1
+              prefixlength: 128
+            none: ~
+            not-configured:
+              address: ""
+              prefixlength: 128
           _pools:
             http:
               frontend:

--- a/tests/golden/defaults/cloudscale-loadbalancer-controller/cloudscale-loadbalancer-controller/20_loadbalancers.yaml
+++ b/tests/golden/defaults/cloudscale-loadbalancer-controller/cloudscale-loadbalancer-controller/20_loadbalancers.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   floatingIPAddresses:
     - cidr: 192.0.2.100/32
+    - cidr: 3fff::1/128
+    - cidr: 3fff::100/128
   pools:
     - backend:
         healthMonitor:


### PR DESCRIPTION
We extend the component's `LoadBalancer` resource generation to support `.spec._floatingIPAddresses` which makes configuring floating IP addresses through the hierarchy easier.

This is required for easy gradual configuration of optional IPv6 floating IPs, cf. https://github.com/appuio/component-openshift4-terraform/pull/142

Note: This shouldn't break any current custom VSHN configurations.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
